### PR TITLE
S3 uri parsing fix

### DIFF
--- a/src/worker/manager.rs
+++ b/src/worker/manager.rs
@@ -176,12 +176,12 @@ impl WorkerState {
     pub async fn get_used_storage(&self) -> Result<u64> {
         let stats = nix::sys::statvfs::statvfs(&self.config.data_path)?;
         let used_blocks = stats.blocks() - stats.blocks_available();
-        Ok(used_blocks * stats.block_size())
+        Ok((used_blocks as u64) * stats.block_size())
     }
 
     pub async fn get_free_storage(&self) -> Result<u64> {
         let stats = nix::sys::statvfs::statvfs(&self.config.data_path)?;
-        let all_free = stats.blocks_available() * stats.block_size();
+        let all_free = (stats.blocks_available() as u64) * stats.block_size();
         Ok(self.config.data_limit.min(all_free))
     }
 


### PR DESCRIPTION
* Fixed S3 credential parsing issue that would merge provided password with specified port, if the port was in the S3 URI
* Assign http or https scheme to S3 endpoint_url as required by S3 client implementation, support for enabling/disabling SSL using the use_ssl parameter.
* Fixed integer multiplication compiler type error with casting to allow compilation.